### PR TITLE
Fix sales filtering and receipt handling

### DIFF
--- a/filter_sales.php
+++ b/filter_sales.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/env/bootstrap.php';
+require_once __DIR__ . '/includes/sales_table_renderer.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo '<div class="text-center py-8 text-red-500">درخواست نامعتبر است.</div>';
+    exit();
+}
+
+$dateFilter = trim((string) ($_POST['date'] ?? ''));
+$searchTerm = trim((string) ($_POST['search'] ?? ''));
+
+try {
+    if ($dateFilter !== '') {
+        $dateFilter = validate_date($dateFilter);
+    }
+} catch (Throwable $e) {
+    http_response_code(422);
+    $message = htmlspecialchars(normalize_error_message($e), ENT_QUOTES, 'UTF-8');
+    echo '<div class="text-center py-8 text-red-500">' . $message . '</div>';
+    exit();
+}
+
+$conditions = [];
+$params = [];
+$types = '';
+
+if ($dateFilter !== '') {
+    $conditions[] = 'DATE(s.sale_date) = ?';
+    $params[] = $dateFilter;
+    $types .= 's';
+}
+
+if ($searchTerm !== '') {
+    $conditions[] = '('
+        . 'CAST(s.sale_id AS CHAR) LIKE ? OR '
+        . 'COALESCE(c.name, "") LIKE ? OR '
+        . 's.payment_method LIKE ? OR '
+        . 's.status LIKE ?'
+        . ')';
+    $likeTerm = '%' . $searchTerm . '%';
+    $params[] = $likeTerm;
+    $params[] = $likeTerm;
+    $params[] = $likeTerm;
+    $params[] = $likeTerm;
+    $types .= 'ssss';
+}
+
+$query = 'SELECT s.*, c.name AS customer_name, COUNT(si.sale_item_id) AS item_count, '
+    . 'SUM(si.quantity * si.sell_price) AS total_amount '
+    . 'FROM Sales s '
+    . 'LEFT JOIN Customers c ON s.customer_id = c.customer_id '
+    . 'LEFT JOIN Sale_Items si ON s.sale_id = si.sale_id';
+
+if ($conditions !== []) {
+    $query .= ' WHERE ' . implode(' AND ', $conditions);
+}
+
+$query .= ' GROUP BY s.sale_id ORDER BY s.sale_date DESC, s.sale_id DESC';
+
+$stmt = $conn->prepare($query);
+if ($stmt === false) {
+    http_response_code(500);
+    echo '<div class="text-center py-8 text-red-500">خطا در آماده‌سازی کوئری فیلتر.</div>';
+    exit();
+}
+
+if ($params !== []) {
+    $bindParams = [];
+    $bindParams[] = &$types;
+    foreach ($params as $key => $value) {
+        $bindParams[] = &$params[$key];
+    }
+
+    call_user_func_array([$stmt, 'bind_param'], $bindParams);
+}
+
+try {
+    $stmt->execute();
+    $result = $stmt->get_result();
+    echo render_sales_table($result);
+} catch (Throwable $e) {
+    http_response_code(500);
+    $message = htmlspecialchars(normalize_error_message($e), ENT_QUOTES, 'UTF-8');
+    echo '<div class="text-center py-8 text-red-500">' . $message . '</div>';
+} finally {
+    $stmt->close();
+}

--- a/includes/sales_table_renderer.php
+++ b/includes/sales_table_renderer.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Render the sales table markup used on the sales listing page.
+ *
+ * @param mysqli_result|false $salesResult
+ */
+function render_sales_table(mysqli_result|false $salesResult): string
+{
+    ob_start();
+    ?>
+    <table id="salesTable" class="w-full text-sm text-gray-900">
+        <thead class="bg-gradient-to-r from-blue-50 to-indigo-50 border-b border-gray-300">
+            <tr>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">شماره فروش</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">مشتری</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">تاریخ</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">روش پرداخت</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">وضعیت</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">تعداد آیتم</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">مجموع</th>
+                <th class="px-6 py-4 text-right text-xs font-bold text-blue-700 uppercase tracking-wider">عملیات</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-100">
+            <?php if ($salesResult === false): ?>
+                <tr>
+                    <td colspan="8" class="px-6 py-8 text-center text-red-600">
+                        خطا در بارگذاری اطلاعات فروش. لطفاً بعداً دوباره تلاش کنید.
+                    </td>
+                </tr>
+            <?php elseif ($salesResult->num_rows === 0): ?>
+                <tr>
+                    <td colspan="8" class="px-6 py-8 text-center">
+                        <i data-feather="shopping-cart" class="w-12 h-12 text-gray-400 mx-auto mb-4"></i>
+                        <h3 class="text-lg font-medium text-gray-700 mb-2">هنوز فروشی ثبت نشده است</h3>
+                        <p class="text-gray-500 mb-4">برای شروع، اولین فروش خود را ثبت کنید</p>
+                        <button onclick="openModal('newSaleModal')" class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors">
+                            ایجاد اولین فروش
+                        </button>
+                    </td>
+                </tr>
+            <?php else: ?>
+                <?php while ($sale = $salesResult->fetch_assoc()): ?>
+                    <?php
+                    $sale_id = (int) $sale['sale_id'];
+                    $customer_id = isset($sale['customer_id']) ? (int) $sale['customer_id'] : 0;
+                    $customer_name = htmlspecialchars($sale['customer_name'] ?: 'مشتری حضوری', ENT_QUOTES, 'UTF-8');
+                    $sale_date = htmlspecialchars((string) $sale['sale_date'], ENT_QUOTES, 'UTF-8');
+                    $status = (string) ($sale['status'] ?? 'pending');
+                    $payment_method = (string) ($sale['payment_method'] ?? 'cash');
+                    $item_count = (int) ($sale['item_count'] ?? 0);
+                    $total_amount = number_format((float) ($sale['total_amount'] ?? 0), 0);
+
+                    $status_color = $status === 'paid' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800';
+                    $status_label = $status === 'paid' ? 'پرداخت شده' : 'در انتظار پرداخت';
+
+                    $payment_icon = 'repeat';
+                    $payment_text = 'انتقال بانکی';
+
+                    if ($payment_method === 'cash') {
+                        $payment_icon = 'dollar-sign';
+                        $payment_text = 'نقدی';
+                    } elseif ($payment_method === 'credit_card') {
+                        $payment_icon = 'credit-card';
+                        $payment_text = 'کارت اعتباری';
+                    }
+
+                    $sale_date_json = json_encode((string) $sale['sale_date'], JSON_UNESCAPED_UNICODE);
+                    $payment_method_json = json_encode($payment_method, JSON_UNESCAPED_UNICODE);
+                    $status_json = json_encode($status, JSON_UNESCAPED_UNICODE);
+
+                    $edit_callback = sprintf(
+                        'openEditSaleModal(%d, %d, %s, %s, %s)',
+                        $sale_id,
+                        $customer_id,
+                        $sale_date_json,
+                        $payment_method_json,
+                        $status_json
+                    );
+                    $edit_callback_escaped = htmlspecialchars($edit_callback, ENT_QUOTES, 'UTF-8');
+                    ?>
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">#فروش-<?php echo $sale_id; ?></td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo $customer_name; ?></td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo $sale_date; ?></td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <div class="flex items-center">
+                                <i data-feather="<?php echo htmlspecialchars($payment_icon, ENT_QUOTES, 'UTF-8'); ?>" class="w-4 h-4 ml-1"></i>
+                                <?php echo htmlspecialchars($payment_text, ENT_QUOTES, 'UTF-8'); ?>
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <span class="px-2 py-1 text-xs font-semibold rounded-full <?php echo $status_color; ?>"><?php echo $status_label; ?></span>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo $item_count; ?></td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-bold text-gray-900"><?php echo $total_amount; ?> تومان</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                            <div class="flex space-x-2 space-x-reverse">
+                                <button onclick="printReceipt(event, <?php echo $sale_id; ?>)" class="p-1 bg-green-100 rounded text-green-600 hover:bg-green-200 transition-colors" title="چاپ رسید">
+                                    <i data-feather="printer" class="w-4 h-4"></i>
+                                </button>
+                                <button onclick="<?php echo $edit_callback_escaped; ?>" class="p-1 bg-yellow-100 rounded text-yellow-600 hover:bg-yellow-200 transition-colors" title="ویرایش">
+                                    <i data-feather="edit" class="w-4 h-4"></i>
+                                </button>
+                                <a href="?delete_sale=<?php echo $sale_id; ?>" onclick="return confirm('آیا مطمئن هستید که می‌خواهید این فروش را حذف کنید؟')" class="p-1 bg-red-100 rounded text-red-600 hover:bg-red-200 transition-colors" title="حذف">
+                                    <i data-feather="trash-2" class="w-4 h-4"></i>
+                                </a>
+                                <button onclick="showSaleItems(<?php echo $sale_id; ?>)" class="p-1 bg-blue-100 rounded text-blue-600 hover:bg-blue-200 transition-colors" title="مشاهده آیتم‌ها">
+                                    <i data-feather="eye" class="w-4 h-4"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endwhile; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+    <?php
+
+    if ($salesResult instanceof mysqli_result) {
+        $salesResult->free();
+    }
+
+    return (string) ob_get_clean();
+}


### PR DESCRIPTION
## Summary
- add a reusable sales table renderer and call it from sales.php and the new filter_sales.php endpoint
- implement filter_sales.php to validate input, execute the filtered query, and return the shared table markup
- validate editable sell prices on the server, pass the event object to printReceipt, and reinitialize DataTables after filtering

## Testing
- php -l sales.php
- php -l filter_sales.php
- php -l includes/sales_table_renderer.php

------
https://chatgpt.com/codex/tasks/task_b_68dfab0932e08322ae005fa67ad3342d