### PR TITLE
Add supplier balance tracking to monthly purchases report

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -113,6 +113,34 @@ CREATE TABLE Purchase_Items (
     FOREIGN KEY (variant_id) REFERENCES Product_Variants(variant_id) ON DELETE CASCADE
 );
 
+-- Purchase Returns table (returned goods to suppliers)
+CREATE TABLE Purchase_Returns (
+    purchase_return_id INT AUTO_INCREMENT PRIMARY KEY,
+    purchase_id INT NULL,
+    supplier_id INT NOT NULL,
+    return_date DATE NOT NULL,
+    total_amount DECIMAL(15,2) NOT NULL DEFAULT 0,
+    note TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (purchase_id) REFERENCES Purchases(purchase_id) ON DELETE SET NULL,
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
+);
+
+-- Supplier Balances table (opening and closing debt per supplier per month)
+CREATE TABLE Supplier_Balances (
+    balance_id INT AUTO_INCREMENT PRIMARY KEY,
+    supplier_id INT NOT NULL,
+    balance_year INT NOT NULL,
+    balance_month INT NOT NULL,
+    opening_balance DECIMAL(15,2) NOT NULL DEFAULT 0,
+    total_purchases DECIMAL(15,2) NOT NULL DEFAULT 0,
+    total_returns DECIMAL(15,2) NOT NULL DEFAULT 0,
+    closing_balance DECIMAL(15,2) NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY supplier_month (supplier_id, balance_year, balance_month),
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
+);
+
 -- Insert some sample data
 INSERT INTO Customers (name, phone, email) VALUES
 ('مشتری نمونه ۱', '09123456789', 'customer1@example.com'),

--- a/update_db.php
+++ b/update_db.php
@@ -26,6 +26,34 @@ $return_items_sql = "CREATE TABLE IF NOT EXISTS Return_Items (
     FOREIGN KEY (variant_id) REFERENCES Product_Variants(variant_id) ON DELETE CASCADE
 )";
 
+// SQL to create Purchase_Returns table
+$purchase_returns_sql = "CREATE TABLE IF NOT EXISTS Purchase_Returns (
+    purchase_return_id INT AUTO_INCREMENT PRIMARY KEY,
+    purchase_id INT NULL,
+    supplier_id INT NOT NULL,
+    return_date DATE NOT NULL,
+    total_amount DECIMAL(15,2) NOT NULL DEFAULT 0,
+    note TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (purchase_id) REFERENCES Purchases(purchase_id) ON DELETE SET NULL,
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
+)";
+
+// SQL to create Supplier_Balances table
+$supplier_balances_sql = "CREATE TABLE IF NOT EXISTS Supplier_Balances (
+    balance_id INT AUTO_INCREMENT PRIMARY KEY,
+    supplier_id INT NOT NULL,
+    balance_year INT NOT NULL,
+    balance_month INT NOT NULL,
+    opening_balance DECIMAL(15,2) NOT NULL DEFAULT 0,
+    total_purchases DECIMAL(15,2) NOT NULL DEFAULT 0,
+    total_returns DECIMAL(15,2) NOT NULL DEFAULT 0,
+    closing_balance DECIMAL(15,2) NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY supplier_month (supplier_id, balance_year, balance_month),
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
+)";
+
 try {
     // Create Returns table
     if ($conn->query($returns_sql) === TRUE) {
@@ -39,6 +67,20 @@ try {
         echo "جدول Return_Items با موفقیت ایجاد شد<br>";
     } else {
         echo "خطا در ایجاد جدول Return_Items: " . $conn->error . "<br>";
+    }
+
+    // Create Purchase_Returns table
+    if ($conn->query($purchase_returns_sql) === TRUE) {
+        echo "جدول Purchase_Returns با موفقیت ایجاد شد<br>";
+    } else {
+        echo "خطا در ایجاد جدول Purchase_Returns: " . $conn->error . "<br>";
+    }
+
+    // Create Supplier_Balances table
+    if ($conn->query($supplier_balances_sql) === TRUE) {
+        echo "جدول Supplier_Balances با موفقیت ایجاد شد<br>";
+    } else {
+        echo "خطا در ایجاد جدول Supplier_Balances: " . $conn->error . "<br>";
     }
 
     echo "به‌روزرسانی دیتابیس کامل شد!";


### PR DESCRIPTION
## Summary
- add schema support for purchase returns and supplier balance snapshots
- extend monthly purchases reporting logic to aggregate returns, balances, and per-supplier breakdowns
- render enhanced monthly summaries in the purchases view for invoice reconciliation

## Testing
- php -l purchases.php
- php -l update_db.php

------
https://chatgpt.com/codex/tasks/task_b_68dfc204ae988322aebbfafa0f787eee