### PR TITLE
Implement supplier return workflow

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -61,23 +61,28 @@ CREATE TABLE Sale_Items (
     FOREIGN KEY (variant_id) REFERENCES Product_Variants(variant_id) ON DELETE CASCADE
 );
 
--- Returns table
 CREATE TABLE Returns (
     return_id INT AUTO_INCREMENT PRIMARY KEY,
-    customer_id INT DEFAULT 0, -- 0 for walk-in customers
+    purchase_id INT NOT NULL,
+    supplier_id INT NOT NULL,
     return_date DATE NOT NULL,
     reason TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (purchase_id) REFERENCES Purchases(purchase_id) ON DELETE CASCADE,
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
 );
 
 -- Return Items table
 CREATE TABLE Return_Items (
     return_item_id INT AUTO_INCREMENT PRIMARY KEY,
     return_id INT NOT NULL,
+    purchase_item_id INT NOT NULL,
     variant_id INT NOT NULL,
     quantity INT NOT NULL,
     return_price DECIMAL(10,2) NOT NULL,
     FOREIGN KEY (return_id) REFERENCES Returns(return_id) ON DELETE CASCADE,
+    FOREIGN KEY (purchase_item_id) REFERENCES Purchase_Items(purchase_item_id) ON DELETE CASCADE,
     FOREIGN KEY (variant_id) REFERENCES Product_Variants(variant_id) ON DELETE CASCADE
 );
 

--- a/get_purchase_return_items.php
+++ b/get_purchase_return_items.php
@@ -1,0 +1,80 @@
+<?php
+require_once __DIR__ . '/env/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $purchase_id = validate_int($_GET['purchase_id'] ?? null, 1);
+} catch (Throwable $e) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'شناسه خرید نامعتبر است.'
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$purchaseStmt = $conn->prepare('SELECT p.purchase_id, p.purchase_date, p.supplier_id, s.name AS supplier_name FROM Purchases p JOIN Suppliers s ON p.supplier_id = s.supplier_id WHERE p.purchase_id = ?');
+$purchaseStmt->bind_param('i', $purchase_id);
+$purchaseStmt->execute();
+$purchase = $purchaseStmt->get_result()->fetch_assoc();
+
+if (!$purchase) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'خرید موردنظر یافت نشد.'
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$itemsStmt = $conn->prepare(
+    'SELECT
+        pi.purchase_item_id,
+        pi.variant_id,
+        pi.quantity,
+        pi.buy_price,
+        pr.model_name,
+        pv.color,
+        pv.size,
+        COALESCE(SUM(ri.quantity), 0) AS returned_quantity
+    FROM Purchase_Items pi
+    JOIN Product_Variants pv ON pi.variant_id = pv.variant_id
+    JOIN Products pr ON pv.product_id = pr.product_id
+    LEFT JOIN Return_Items ri ON ri.purchase_item_id = pi.purchase_item_id
+    LEFT JOIN Returns r ON r.return_id = ri.return_id AND r.purchase_id = pi.purchase_id
+    WHERE pi.purchase_id = ?
+    GROUP BY pi.purchase_item_id, pi.variant_id, pi.quantity, pi.buy_price, pr.model_name, pv.color, pv.size'
+);
+$itemsStmt->bind_param('i', $purchase_id);
+$itemsStmt->execute();
+$itemsResult = $itemsStmt->get_result();
+
+$items = [];
+while ($row = $itemsResult->fetch_assoc()) {
+    $quantityPurchased = (int) $row['quantity'];
+    $returnedQuantity = (int) $row['returned_quantity'];
+    $availableQuantity = max(0, $quantityPurchased - $returnedQuantity);
+
+    $items[] = [
+        'purchase_item_id' => (int) $row['purchase_item_id'],
+        'variant_id' => (int) $row['variant_id'],
+        'quantity' => $quantityPurchased,
+        'available_quantity' => $availableQuantity,
+        'buy_price' => (float) $row['buy_price'],
+        'product_name' => (string) $row['model_name'],
+        'color' => (string) $row['color'],
+        'size' => (string) $row['size'],
+    ];
+}
+
+$response = [
+    'success' => true,
+    'purchase' => [
+        'purchase_id' => (int) $purchase['purchase_id'],
+        'purchase_date' => (string) $purchase['purchase_date'],
+        'supplier_id' => (int) $purchase['supplier_id'],
+        'supplier_name' => (string) $purchase['supplier_name'],
+    ],
+    'items' => $items,
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE);

--- a/update_db.php
+++ b/update_db.php
@@ -9,20 +9,26 @@ include 'env/db.php';
 // SQL to create Returns table
 $returns_sql = "CREATE TABLE IF NOT EXISTS Returns (
     return_id INT AUTO_INCREMENT PRIMARY KEY,
-    customer_id INT DEFAULT 0,
+    purchase_id INT NOT NULL,
+    supplier_id INT NOT NULL,
     return_date DATE NOT NULL,
     reason TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (purchase_id) REFERENCES Purchases(purchase_id) ON DELETE CASCADE,
+    FOREIGN KEY (supplier_id) REFERENCES Suppliers(supplier_id) ON DELETE CASCADE
 )";
 
 // SQL to create Return_Items table
 $return_items_sql = "CREATE TABLE IF NOT EXISTS Return_Items (
     return_item_id INT AUTO_INCREMENT PRIMARY KEY,
     return_id INT NOT NULL,
+    purchase_item_id INT NOT NULL,
     variant_id INT NOT NULL,
     quantity INT NOT NULL,
     return_price DECIMAL(10,2) NOT NULL,
     FOREIGN KEY (return_id) REFERENCES Returns(return_id) ON DELETE CASCADE,
+    FOREIGN KEY (purchase_item_id) REFERENCES Purchase_Items(purchase_item_id) ON DELETE CASCADE,
     FOREIGN KEY (variant_id) REFERENCES Product_Variants(variant_id) ON DELETE CASCADE
 )";
 


### PR DESCRIPTION
## Summary
- switch the return workflow to operate on supplier purchases, including form updates and validation
- persist purchase-linked return records, adjust inventory, and expose supplier details in return listings
- extend the schema and database helpers to support purchase-linked returns and expose purchase items for the UI

## Testing
- php -l returns.php
- php -l get_purchase_return_items.php
- php -l get_return_items.php
- php -l update_db.php

------
https://chatgpt.com/codex/tasks/task_b_68dfc20579408322b6429c48412c0387