### PR TITLE
Enforce consistent Jalali date formatting

### DIFF
--- a/env/bootstrap.php
+++ b/env/bootstrap.php
@@ -6,6 +6,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 }
 
 require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/../jalali_calendar.php';
 
 if (empty($_SESSION['user_id'])) {
     header('Location: login.php');
@@ -48,12 +49,11 @@ function redirect_with_message(string $location, string $type, string $message):
 
 function validate_date(string $value): string
 {
-    $date = DateTime::createFromFormat('Y-m-d', $value);
-    if (!$date || $date->format('Y-m-d') !== $value) {
+    try {
+        return jalali_to_gregorian_string($value);
+    } catch (Throwable $e) {
         throw new InvalidArgumentException('تاریخ نامعتبر است.');
     }
-
-    return $value;
 }
 
 function validate_int(mixed $value, int $min = 0): int

--- a/get_all_purchase_items.php
+++ b/get_all_purchase_items.php
@@ -3,9 +3,20 @@ require_once __DIR__ . '/env/bootstrap.php';
 
 header('Content-Type: application/json');
 
-$purchase_date = $_GET['purchase_date'] ?? null;
+$purchase_date_input = isset($_GET['purchase_date']) ? (string) $_GET['purchase_date'] : null;
 $model_name = $_GET['model_name'] ?? null;
 $color = $_GET['color'] ?? null;
+
+$purchase_date = null;
+if ($purchase_date_input !== null && $purchase_date_input !== '') {
+    try {
+        $purchase_date = validate_date($purchase_date_input);
+    } catch (Throwable $e) {
+        http_response_code(422);
+        echo json_encode(['error' => normalize_error_message($e)]);
+        exit();
+    }
+}
 
 if ($purchase_date && $model_name && $color) {
     $stmt = $conn->prepare("
@@ -22,6 +33,7 @@ if ($purchase_date && $model_name && $color) {
     $result = $stmt->get_result();
     $data = [];
     while ($item = $result->fetch_assoc()) {
+        $item['purchase_date'] = convert_gregorian_to_jalali_for_display((string) $item['purchase_date']);
         $data[] = $item;
     }
     $stmt->close();
@@ -37,6 +49,7 @@ if ($purchase_date && $model_name && $color) {
 
     $data = [];
     while ($item = $allPurchaseItems->fetch_assoc()) {
+        $item['purchase_date'] = convert_gregorian_to_jalali_for_display((string) $item['purchase_date']);
         $data[] = $item;
     }
 }

--- a/get_return_items.php
+++ b/get_return_items.php
@@ -30,7 +30,7 @@ $itemsStmt->execute();
 $itemsResult = $itemsStmt->get_result();
 
 $customer_name = htmlspecialchars($return['customer_name'] ?: 'مشتری حضوری', ENT_QUOTES, 'UTF-8');
-$return_date = htmlspecialchars((string) $return['return_date'], ENT_QUOTES, 'UTF-8');
+$return_date = htmlspecialchars(convert_gregorian_to_jalali_for_display((string) $return['return_date']), ENT_QUOTES, 'UTF-8');
 $reason = htmlspecialchars((string) ($return['reason'] ?? ''), ENT_QUOTES, 'UTF-8');
 
 echo '<div class="space-y-6">';

--- a/get_sale_receipt.php
+++ b/get_sale_receipt.php
@@ -62,7 +62,7 @@ $payment_methods = [
 ];
 $payment_text = htmlspecialchars($payment_methods[$sale['payment_method']] ?? $sale['payment_method'], ENT_QUOTES, 'UTF-8');
 $customer_name = htmlspecialchars($sale['customer_name'] ?: 'مشتری حضوری', ENT_QUOTES, 'UTF-8');
-$sale_date = htmlspecialchars((string) $sale['sale_date'], ENT_QUOTES, 'UTF-8');
+$sale_date = htmlspecialchars(convert_gregorian_to_jalali_for_display((string) $sale['sale_date']), ENT_QUOTES, 'UTF-8');
 $status_text = $sale['status'] === 'paid' ? 'پرداخت شده' : 'در انتظار پرداخت';
 $status_text = htmlspecialchars($status_text, ENT_QUOTES, 'UTF-8');
 ?>

--- a/includes/sales_table_renderer.php
+++ b/includes/sales_table_renderer.php
@@ -47,7 +47,8 @@ function render_sales_table(mysqli_result|false $salesResult): string
                     $sale_id = (int) $sale['sale_id'];
                     $customer_id = isset($sale['customer_id']) ? (int) $sale['customer_id'] : 0;
                     $customer_name = htmlspecialchars($sale['customer_name'] ?: 'مشتری حضوری', ENT_QUOTES, 'UTF-8');
-                    $sale_date = htmlspecialchars((string) $sale['sale_date'], ENT_QUOTES, 'UTF-8');
+                    $sale_date_value = convert_gregorian_to_jalali_for_display((string) $sale['sale_date']);
+                    $sale_date = htmlspecialchars($sale_date_value, ENT_QUOTES, 'UTF-8');
                     $status = (string) ($sale['status'] ?? 'pending');
                     $payment_method = (string) ($sale['payment_method'] ?? 'cash');
                     $item_count = (int) ($sale['item_count'] ?? 0);
@@ -67,7 +68,7 @@ function render_sales_table(mysqli_result|false $salesResult): string
                         $payment_text = 'کارت اعتباری';
                     }
 
-                    $sale_date_json = json_encode((string) $sale['sale_date'], JSON_UNESCAPED_UNICODE);
+                    $sale_date_json = json_encode($sale_date_value, JSON_UNESCAPED_UNICODE);
                     $payment_method_json = json_encode($payment_method, JSON_UNESCAPED_UNICODE);
                     $status_json = json_encode($status, JSON_UNESCAPED_UNICODE);
 

--- a/index.php
+++ b/index.php
@@ -20,10 +20,12 @@ $low_stock = $conn->query("SELECT p.model_name, pv.color, pv.size, pv.stock FROM
 
 // Get sales data for last 30 days for chart
 $sales_chart_data = [];
+$sales_chart_labels = [];
 for ($i = 29; $i >= 0; $i--) {
     $date = date('Y-m-d', strtotime("-$i days"));
     $amount = $conn->query("SELECT SUM(si.quantity * si.sell_price) as total FROM Sales s JOIN Sale_Items si ON s.sale_id = si.sale_id WHERE DATE(s.sale_date) = '$date'")->fetch_assoc()['total'] ?: 0;
     $sales_chart_data[] = $amount;
+    $sales_chart_labels[] = convert_gregorian_to_jalali_for_display($date);
 }
 
 // Get top products for bar chart
@@ -128,7 +130,7 @@ while ($row = $top_products_query->fetch_assoc()) {
                 <h2 class="text-xl font-semibold text-gray-800">داشبورد</h2>
                 <div class="flex items-center space-x-4">
                     <div class="text-sm text-gray-500">
-                        <?php echo date('l j F Y'); ?>
+                        <?php echo htmlspecialchars(get_current_jalali_date_string(), ENT_QUOTES, 'UTF-8'); ?>
                     </div>
                 </div>
             </header>
@@ -321,13 +323,7 @@ while ($row = $top_products_query->fetch_assoc()) {
         const salesChart = new Chart(salesCtx, {
             type: 'line',
             data: {
-                labels: [
-                    <?php
-                    for ($i = 29; $i >= 0; $i--) {
-                        echo "'" . date('m/d', strtotime("-$i days")) . "',";
-                    }
-                    ?>
-                ],
+                labels: [<?php echo "'" . implode("','", $sales_chart_labels) . "'"; ?>],
                 datasets: [{
                     label: 'فروش روزانه (تومان)',
                     data: [<?php echo implode(',', $sales_chart_data); ?>],

--- a/returns.php
+++ b/returns.php
@@ -320,7 +320,7 @@ $returns = $conn->query("SELECT r.*, 'مشتری حضوری' as customer_name, C
                                 while($return = $returns->fetch_assoc()){
                                     $return_id = (int) $return['return_id'];
                                     $customer_name = htmlspecialchars($return['customer_name'] ?: 'مشتری حضوری', ENT_QUOTES, 'UTF-8');
-                                    $return_date = htmlspecialchars((string) $return['return_date'], ENT_QUOTES, 'UTF-8');
+                                    $return_date = htmlspecialchars(convert_gregorian_to_jalali_for_display((string) $return['return_date']), ENT_QUOTES, 'UTF-8');
                                     $reason = htmlspecialchars((string) ($return['reason'] ?? ''), ENT_QUOTES, 'UTF-8');
                                     $item_count = (int) $return['item_count'];
                                     $total_amount = number_format((float) ($return['total_amount'] ?? 0), 0);
@@ -453,7 +453,7 @@ $returns = $conn->query("SELECT r.*, 'مشتری حضوری' as customer_name, C
                                                 </div>
                                                 <div>
                                                     <label class="block text-sm font-medium text-gray-700 mb-1">تاریخ مرجوعی</label>
-                                                    <input type="date" name="return_date" value="<?php echo date('Y-m-d'); ?>" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                                    <input type="text" name="return_date" value="<?php echo htmlspecialchars(get_current_jalali_date_string(), ENT_QUOTES, 'UTF-8'); ?>" placeholder="مثال: 1404/07/07" inputmode="numeric" pattern="[0-9]{4}/[0-9]{2}/[0-9]{2}" dir="ltr" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
                                                 </div>
                                                 <div>
                                                     <label class="block text-sm font-medium text-gray-700 mb-1">دلیل مرجوعی</label>

--- a/sales.php
+++ b/sales.php
@@ -678,7 +678,7 @@ $products = $conn->query('SELECT DISTINCT p.* FROM Products p JOIN Product_Varia
                         <div class="flex flex-col sm:flex-row items-start sm:items-center space-y-3 sm:space-y-0 sm:space-x-4 sm:space-x-reverse">
                             <div class="relative">
                                 <i data-feather="calendar" class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
-                                <input type="date" id="dateFilter" class="pr-10 pl-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                <input type="text" id="dateFilter" placeholder="مثال: 1404/07/07" inputmode="numeric" pattern="[0-9]{4}/[0-9]{2}/[0-9]{2}" dir="ltr" class="pr-10 pl-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
                             </div>
                             <div class="relative">
                                 <i data-feather="search" class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
@@ -804,7 +804,7 @@ $products = $conn->query('SELECT DISTINCT p.* FROM Products p JOIN Product_Varia
                                                 </div>
                                                 <div>
                                                     <label class="block text-sm font-medium text-gray-700 mb-1">تاریخ فروش</label>
-                                                    <input type="date" name="sale_date" value="<?php echo date('Y-m-d'); ?>" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                                    <input type="text" name="sale_date" value="<?php echo htmlspecialchars(get_current_jalali_date_string(), ENT_QUOTES, 'UTF-8'); ?>" placeholder="مثال: 1404/07/07" inputmode="numeric" pattern="[0-9]{4}/[0-9]{2}/[0-9]{2}" dir="ltr" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
                                                 </div>
 
                                                 <div class="pt-4 border-t border-gray-200">
@@ -864,7 +864,7 @@ $products = $conn->query('SELECT DISTINCT p.* FROM Products p JOIN Product_Varia
                                     </div>
                                     <div>
                                         <label class="block text-sm font-medium text-gray-700 mb-1">تاریخ فروش</label>
-                                        <input type="date" name="sale_date" id="edit_sale_date" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                        <input type="text" name="sale_date" id="edit_sale_date" placeholder="مثال: 1404/07/07" inputmode="numeric" pattern="[0-9]{4}/[0-9]{2}/[0-9]{2}" dir="ltr" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
                                     </div>
                                     <div>
                                         <label class="block text-sm font-medium text-gray-700 mb-1">روش پرداخت</label>


### PR DESCRIPTION
## Summary
- extend the Jalali calendar utilities with parsing/formatting helpers so the app can convert between Jalali strings and Gregorian storage values
- validate Jalali date strings centrally and switch sales, returns, purchases, and receipt views to display the YYYY/MM/DD Jalali format
- update AJAX responses and dashboard charts to surface Jalali dates in listings, detail modals, and analytics labels

## Testing
- php -l jalali_calendar.php
- php -l env/bootstrap.php
- php -l includes/sales_table_renderer.php
- php -l sales.php
- php -l get_sale_receipt.php
- php -l returns.php
- php -l get_return_items.php
- php -l purchases.php
- php -l get_all_purchase_items.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_b_68e4ec71be6883228ffaeb7204b1b229