### PR TITLE
Resolve sales page client-side errors

### DIFF
--- a/env/bootstrap.php
+++ b/env/bootstrap.php
@@ -70,6 +70,24 @@ function validate_int(mixed $value, int $min = 0): int
     return $int;
 }
 
+function validate_price(mixed $value): float
+{
+    if (is_string($value)) {
+        $value = str_replace([',', ' '], '', $value);
+    }
+
+    if (!is_numeric($value)) {
+        throw new InvalidArgumentException('قیمت وارد شده نامعتبر است.');
+    }
+
+    $price = (float) $value;
+    if ($price <= 0) {
+        throw new InvalidArgumentException('قیمت باید بزرگتر از صفر باشد.');
+    }
+
+    return round($price, 2);
+}
+
 function validate_enum(string $value, array $allowed): string
 {
     if (!in_array($value, $allowed, true)) {


### PR DESCRIPTION
## Summary
- stop loading the DataTables language JSON file as a script to avoid syntax errors in the browser
- allow the manual sell price field to be validated in JavaScript without triggering hidden form control errors
- guard the out-of-stock toggle logic so it only runs when the related button exists on the page

## Testing
- php -l env/bootstrap.php
- php -l sales.php

------
https://chatgpt.com/codex/tasks/task_b_68e5203138d88322ad8cfaee389b700a