### PR TITLE
Fix product price lookup and clean purchase deletion script

### DIFF
--- a/delete_purchase_item.php
+++ b/delete_purchase_item.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 require_once __DIR__ . '/env/bootstrap.php';
 
 header('Content-Type: application/json');

--- a/get_product_price.php
+++ b/get_product_price.php
@@ -12,14 +12,18 @@ if (!isset($_GET['variant_id']) || !is_numeric($_GET['variant_id'])) {
 $variantId = (int) $_GET['variant_id'];
 
 try {
-    $stmt = $conn->prepare("SELECT buy_price FROM Product_Variants WHERE variant_id = ?");
+    $stmt = $conn->prepare("SELECT price FROM Product_Variants WHERE variant_id = ?");
     $stmt->bind_param('i', $variantId);
     $stmt->execute();
     $result = $stmt->get_result();
     $row = $result->fetch_assoc();
 
     if ($row) {
-        echo json_encode(['buy_price' => (float) $row['buy_price']]);
+        $price = (float) $row['price'];
+        echo json_encode([
+            'price' => $price,
+            'buy_price' => $price,
+        ]);
     } else {
         http_response_code(404);
         echo json_encode(['error' => 'Variant not found']);


### PR DESCRIPTION
## Summary
- correct the product variant price lookup to read the stored price column and return both price keys for compatibility
- remove accidental leading whitespace in the purchase item deletion endpoint to avoid emitting stray output before JSON headers

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68e653bad6508322b452adcad800d3b2